### PR TITLE
Fix vtt2ttml ASS renderer CSS handling

### DIFF
--- a/vtt2ttml/converter_ass.go
+++ b/vtt2ttml/converter_ass.go
@@ -36,7 +36,7 @@ func ConvertToASS(vtt *VTTFile) ([]byte, error) {
 	buf.WriteString("[V4+ Styles]\n")
 	buf.WriteString("Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\n")
 
-	writeASSStyle(&buf, "Default", "&H00FFFFFF&", false)
+	writeASSStyle(&buf, "Default", "&H00FFFFFF&", false, false)
 
 	voices := make([]string, 0, len(vtt.Styles))
 	for v := range vtt.Styles {
@@ -45,7 +45,7 @@ func ConvertToASS(vtt *VTTFile) ([]byte, error) {
 	sort.Strings(voices)
 	for _, voice := range voices {
 		style := vtt.Styles[voice]
-		writeASSStyle(&buf, voice, rgbToASS(style.Color), style.Bold)
+		writeASSStyle(&buf, voice, rgbToASS(style.Color), style.Bold, style.Italic)
 	}
 	buf.WriteString("\n")
 
@@ -65,7 +65,7 @@ func ConvertToASS(vtt *VTTFile) ([]byte, error) {
 			}
 		}
 
-		text := renderNodesASS(cue.Nodes, dominant, vtt.Styles, cue.Settings)
+		text := renderNodesASS(cue.Nodes, dominant, vtt.Styles, vtt.Classes, cue.Settings)
 		fmt.Fprintf(&buf, "Dialogue: 0,%s,%s,%s,,0,0,0,,%s\n", start, end, styleName, text)
 	}
 
@@ -73,18 +73,22 @@ func ConvertToASS(vtt *VTTFile) ([]byte, error) {
 }
 
 // writeASSStyle writes one Style line. All styles use the same font/border defaults;
-// only colour and bold vary.
-func writeASSStyle(buf *bytes.Buffer, name, primaryColour string, bold bool) {
+// only colour, bold, and italic vary.
+func writeASSStyle(buf *bytes.Buffer, name, primaryColour string, bold, italic bool) {
 	boldVal := 0
 	if bold {
 		boldVal = -1
+	}
+	italicVal := 0
+	if italic {
+		italicVal = -1
 	}
 	// Format: Name,Fontname,Fontsize,PrimaryColour,SecondaryColour,OutlineColour,BackColour,
 	//         Bold,Italic,Underline,StrikeOut,ScaleX,ScaleY,Spacing,Angle,
 	//         BorderStyle,Outline,Shadow,Alignment,MarginL,MarginR,MarginV,Encoding
 	fmt.Fprintf(buf,
-		"Style: %s,Arial,48,%s,&H000000FF&,&H00000000&,&H80000000&,%d,0,0,0,100,100,0,0,1,2,0,2,10,10,30,1\n",
-		name, primaryColour, boldVal,
+		"Style: %s,Arial,48,%s,&H000000FF&,&H00000000&,&H80000000&,%d,%d,0,0,100,100,0,0,1,2,0,2,10,10,30,1\n",
+		name, primaryColour, boldVal, italicVal,
 	)
 }
 
@@ -98,78 +102,276 @@ func dominantVoice(nodes []Node) string {
 	return ""
 }
 
-// renderNodesASS produces the ASS Text field for a cue.
-func renderNodesASS(nodes []Node, dominant string, styles map[string]CueStyle, settings CueSettings) string {
+// renderNodesASS produces the ASS Text field for a cue, including any leading
+// positioning/alignment override block derived from cue settings.
+func renderNodesASS(nodes []Node, dominant string, styles, classes map[string]CueStyle, settings CueSettings) string {
 	var b strings.Builder
 
-	// Vertical positioning override for non-default line positions.
-	// line:90 is the default (handled by style MarginV); anything else gets \an + \pos.
-	lv := settings.Line
-	if lv >= 0 && lv != 90 {
-		y := int(lv / 100.0 * float64(assPlayResY))
-		// \an8 = top-centre anchor; text flows downward from y.
-		fmt.Fprintf(&b, "{\\an8\\pos(%d,%d)}", assPlayResX/2, y)
+	if pre := cueSettingsOverride(settings); pre != "" {
+		b.WriteString(pre)
 	}
 
-	renderNodesASSInner(&b, nodes, dominant, styles)
+	state := formatState{color: lineStyleColor(dominant, styles)}
+	renderNodesASSInner(&b, nodes, dominant, styles, classes, state)
 	return b.String()
 }
 
-func renderNodesASSInner(b *strings.Builder, nodes []Node, dominant string, styles map[string]CueStyle) {
+// formatState tracks the currently-active formatting so a span can restore the
+// exact outer state when it closes, instead of emitting broad resets like {\r}
+// that wipe surrounding <b>/<i>/<u>/colour state.
+type formatState struct {
+	color  string // active ASS primary colour, e.g. "&H00FFFFFF&"
+	bold   bool
+	italic bool
+}
+
+// cueSettingsOverride renders the ASS override block for the cue's line/position/align
+// settings. Returns "" when no override is needed.
+func cueSettingsOverride(s CueSettings) string {
+	if s.Line < 0 && !s.PositionSet && s.Align == "" {
+		return ""
+	}
+
+	anH := alignHorizontal(s.Align) // 1=left, 2=centre, 3=right
+
+	if s.Line < 0 {
+		// No explicit vertical position: keep the style's MarginV (bottom alignment).
+		if s.Align == "" {
+			return ""
+		}
+		return fmt.Sprintf("{\\an%d}", anH) // 1/2/3 — bottom-{left,centre,right}
+	}
+
+	// Vertical line is set → anchor at top of text, position at (x, y).
+	y := int(s.Line / 100.0 * float64(assPlayResY))
+	x := assPlayResX / 2
+	if s.PositionSet {
+		x = int(s.Position / 100.0 * float64(assPlayResX))
+	} else {
+		switch anH {
+		case 1:
+			x = 0
+		case 3:
+			x = assPlayResX
+		}
+	}
+	// Top-row alignment: 7=top-left, 8=top-centre, 9=top-right.
+	an := anH + 6
+	// TODO: settings.Size is parsed but not applied — would need \pos + margins.
+	return fmt.Sprintf("{\\an%d\\pos(%d,%d)}", an, x, y)
+}
+
+func alignHorizontal(a string) int {
+	switch strings.ToLower(a) {
+	case "start", "left":
+		return 1
+	case "end", "right":
+		return 3
+	default:
+		return 2
+	}
+}
+
+// lineStyleColor returns the ASS primary colour for the Dialogue line's style,
+// used to restore colour after a voice/class override.
+func lineStyleColor(dominant string, styles map[string]CueStyle) string {
+	if dominant != "" {
+		if s, ok := styles[dominant]; ok {
+			return rgbToASS(s.Color)
+		}
+	}
+	return "&H00FFFFFF&"
+}
+
+// renderNodesASSInner walks the cue AST emitting ASS override tags. The state
+// struct tracks active colour/bold/italic so a closing span can restore exactly
+// the outer formatting instead of issuing a broad {\r} reset.
+func renderNodesASSInner(
+	b *strings.Builder,
+	nodes []Node,
+	dominant string,
+	styles, classes map[string]CueStyle,
+	state formatState,
+) {
 	for _, node := range nodes {
 		switch n := node.(type) {
 		case *TextNode:
-			b.WriteString(strings.ReplaceAll(n.Text, "\n", "\\N"))
+			b.WriteString(escapeASSText(n.Text))
 
 		case *TagNode:
 			switch n.Tag {
 			case "v":
 				if n.Voice == dominant {
-					// Same style as the Dialogue line — no override needed.
-					renderNodesASSInner(b, n.Children, dominant, styles)
+					renderNodesASSInner(b, n.Children, dominant, styles, classes, state)
+				} else if style, ok := styles[n.Voice]; ok {
+					writeStyleSpan(b, style, state, func(inner formatState) {
+						renderNodesASSInner(b, n.Children, dominant, styles, classes, inner)
+					})
 				} else {
-					// Different voice: inline colour (and bold if needed), then reset.
-					if style, ok := styles[n.Voice]; ok {
-						override := fmt.Sprintf("{\\c%s}", rgbToASS(style.Color))
-						if style.Bold {
-							override = fmt.Sprintf("{\\c%s\\b1}", rgbToASS(style.Color))
-						}
-						b.WriteString(override)
-						renderNodesASSInner(b, n.Children, dominant, styles)
-						b.WriteString("{\\r}") // resets to Dialogue style
-					} else {
-						renderNodesASSInner(b, n.Children, dominant, styles)
-					}
+					renderNodesASSInner(b, n.Children, dominant, styles, classes, state)
 				}
+			case "c":
+				style, ok := mergeClassStyles(n.Classes, classes)
+				if !ok {
+					renderNodesASSInner(b, n.Children, dominant, styles, classes, state)
+					break
+				}
+				writeStyleSpan(b, style, state, func(inner formatState) {
+					renderNodesASSInner(b, n.Children, dominant, styles, classes, inner)
+				})
 			case "i":
-				b.WriteString("{\\i1}")
-				renderNodesASSInner(b, n.Children, dominant, styles)
-				b.WriteString("{\\i0}")
+				if state.italic {
+					renderNodesASSInner(b, n.Children, dominant, styles, classes, state)
+				} else {
+					b.WriteString("{\\i1}")
+					renderNodesASSInner(b, n.Children, dominant, styles, classes, formatState{color: state.color, bold: state.bold, italic: true})
+					b.WriteString("{\\i0}")
+				}
 			case "b":
-				b.WriteString("{\\b1}")
-				renderNodesASSInner(b, n.Children, dominant, styles)
-				b.WriteString("{\\b0}")
+				if state.bold {
+					renderNodesASSInner(b, n.Children, dominant, styles, classes, state)
+				} else {
+					b.WriteString("{\\b1}")
+					renderNodesASSInner(b, n.Children, dominant, styles, classes, formatState{color: state.color, bold: true, italic: state.italic})
+					b.WriteString("{\\b0}")
+				}
 			case "u":
 				b.WriteString("{\\u1}")
-				renderNodesASSInner(b, n.Children, dominant, styles)
+				renderNodesASSInner(b, n.Children, dominant, styles, classes, state)
 				b.WriteString("{\\u0}")
 			default:
-				// c, ruby, rt, lang — pass children through.
-				renderNodesASSInner(b, n.Children, dominant, styles)
+				// ruby, rt, lang — pass children through.
+				renderNodesASSInner(b, n.Children, dominant, styles, classes, state)
 			}
 		}
 	}
 }
 
-// rgbToASS converts a CSS hex colour (#RRGGBB) to ASS format (&H00BBGGRR&).
-// ASS stores colours in BBGGRR order with a leading alpha byte (00 = fully opaque).
+// mergeClassStyles folds the styles for each named class (later wins) into one.
+// Returns false if none of the classes have a defined style.
+func mergeClassStyles(classNames []string, classes map[string]CueStyle) (CueStyle, bool) {
+	var merged CueStyle
+	any := false
+	for _, name := range classNames {
+		s, ok := classes[name]
+		if !ok {
+			continue
+		}
+		any = true
+		if s.Color != "" {
+			merged.Color = s.Color
+		}
+		if s.Bold {
+			merged.Bold = true
+		}
+		if s.Italic {
+			merged.Italic = true
+		}
+	}
+	return merged, any
+}
+
+// writeStyleSpan emits the open override for a voice or class span, runs body
+// with the updated format state, then emits the close override that restores
+// exactly the attributes this span changed.
+func writeStyleSpan(b *strings.Builder, style CueStyle, outer formatState, body func(inner formatState)) {
+	inner := outer
+	var open strings.Builder
+	open.WriteByte('{')
+	if style.Color != "" {
+		newColor := rgbToASS(style.Color)
+		if newColor != outer.color {
+			open.WriteString("\\c")
+			open.WriteString(newColor)
+			inner.color = newColor
+		}
+	}
+	if style.Bold && !outer.bold {
+		open.WriteString("\\b1")
+		inner.bold = true
+	}
+	if style.Italic && !outer.italic {
+		open.WriteString("\\i1")
+		inner.italic = true
+	}
+	if open.Len() > 1 {
+		open.WriteByte('}')
+		b.WriteString(open.String())
+	}
+
+	body(inner)
+
+	var close strings.Builder
+	close.WriteByte('{')
+	if inner.color != outer.color {
+		close.WriteString("\\c")
+		close.WriteString(outer.color)
+	}
+	if inner.bold != outer.bold {
+		close.WriteString("\\b0")
+	}
+	if inner.italic != outer.italic {
+		close.WriteString("\\i0")
+	}
+	if close.Len() > 1 {
+		close.WriteByte('}')
+		b.WriteString(close.String())
+	}
+}
+
+// escapeASSText protects cue text from being interpreted as ASS override blocks
+// and converts literal newlines to the ASS hard-break sequence.
+func escapeASSText(s string) string {
+	s = strings.ReplaceAll(s, "{", "\\{")
+	s = strings.ReplaceAll(s, "}", "\\}")
+	s = strings.ReplaceAll(s, "\n", "\\N")
+	return s
+}
+
+// rgbToASS converts a CSS hex colour to ASS format (&HAABBGGRR&).
+// Accepts #RGB, #RRGGBB, and #RRGGBBAA; anything else falls back to white.
+// ASS stores the leading byte as transparency, so CSS alpha AA is inverted.
 func rgbToASS(hex string) string {
 	hex = strings.TrimPrefix(strings.TrimSpace(hex), "#")
 	hex = strings.ToUpper(hex)
-	if len(hex) == 6 {
+	switch len(hex) {
+	case 3:
+		// #RGB → #RRGGBB
+		hex = string([]byte{hex[0], hex[0], hex[1], hex[1], hex[2], hex[2]})
+		fallthrough
+	case 6:
+		if !isHex(hex) {
+			break
+		}
 		return "&H00" + hex[4:6] + hex[2:4] + hex[0:2] + "&"
+	case 8:
+		if !isHex(hex) {
+			break
+		}
+		alpha, err := parseHexByte(hex[6:8])
+		if err != nil {
+			break
+		}
+		transparency := 255 - alpha
+		return fmt.Sprintf("&H%02X%s%s%s&", transparency, hex[4:6], hex[2:4], hex[0:2])
 	}
 	return "&H00FFFFFF&" // fallback: white
+}
+
+func isHex(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
+}
+
+func parseHexByte(s string) (int, error) {
+	var n int
+	_, err := fmt.Sscanf(s, "%02X", &n)
+	return n, err
 }
 
 // formatDurationASS formats a time.Duration as ASS timestamp: H:MM:SS.cc (centiseconds).

--- a/vtt2ttml/parser.go
+++ b/vtt2ttml/parser.go
@@ -57,17 +57,20 @@ type Cue struct {
 
 // VTTFile is the complete parsed representation.
 type VTTFile struct {
-	Lang   string
-	Styles map[string]CueStyle // voice name → style
-	Notes  []string            // NOTE block bodies
-	Cues   []Cue
+	Lang    string
+	Styles  map[string]CueStyle // voice name → style
+	Classes map[string]CueStyle // class name → style (for ::cue(.className))
+	Notes   []string            // NOTE block bodies
+	Cues    []Cue
 }
 
 // ---- Regexps ----
 
 var (
-	reCueVoice = regexp.MustCompile(`(?s)::cue\(v\[voice="([^"]+)"\]\)\s*\{([^}]+)\}`)
+	reCueVoice = regexp.MustCompile(`(?s)::cue\(\s*v\[voice="([^"]+)"\]\s*\)\s*\{([^}]+)\}`)
+	reCueClass = regexp.MustCompile(`(?s)::cue\(\s*\.([A-Za-z0-9_\-]+)\s*\)\s*\{([^}]+)\}`)
 	reHexColor = regexp.MustCompile(`^#[0-9A-Fa-f]{3,8}$`)
+	reBlank    = regexp.MustCompile(`\n{2,}`)
 )
 
 var cssNamedColors = map[string]string{
@@ -85,6 +88,20 @@ var cssNamedColors = map[string]string{
 	"grey":    "#808080",
 	"silver":  "#C0C0C0",
 	"lime":    "#00FF00",
+	"orange":  "#FFA500",
+	"purple":  "#800080",
+	"pink":    "#FFC0CB",
+	"brown":   "#A52A2A",
+	"navy":    "#000080",
+	"teal":    "#008080",
+	"olive":   "#808000",
+	"maroon":  "#800000",
+	"gold":    "#FFD700",
+	"indigo":  "#4B0082",
+	"violet":  "#EE82EE",
+	"coral":   "#FF7F50",
+	"salmon":  "#FA8072",
+	"khaki":   "#F0E68C",
 }
 
 // ---- Public entry point ----
@@ -109,8 +126,9 @@ func ParseVTT(data string) (*VTTFile, error) {
 	}
 
 	vtt := &VTTFile{
-		Lang:   "en",
-		Styles: make(map[string]CueStyle),
+		Lang:    "en",
+		Styles:  make(map[string]CueStyle),
+		Classes: make(map[string]CueStyle),
 	}
 
 	for _, block := range blocks[1:] {
@@ -129,7 +147,7 @@ func ParseVTT(data string) (*VTTFile, error) {
 		case strings.HasPrefix(block, "STYLE"):
 			css := strings.TrimPrefix(block, "STYLE")
 			css = strings.TrimSpace(css)
-			parseStyleBlock(css, vtt.Styles)
+			parseStyleBlock(css, vtt.Styles, vtt.Classes)
 		default:
 			// Check if this block contains a timing arrow.
 			if strings.Contains(block, " --> ") {
@@ -147,22 +165,17 @@ func ParseVTT(data string) (*VTTFile, error) {
 
 // splitBlocks splits the document on one or more consecutive blank lines.
 func splitBlocks(data string) []string {
-	// Replace runs of 2+ newlines with a double newline sentinel.
-	// This handles 3+ blank lines gracefully.
-	for strings.Contains(data, "\n\n\n") {
-		data = strings.ReplaceAll(data, "\n\n\n", "\n\n")
-	}
-	return strings.Split(data, "\n\n")
+	return reBlank.Split(data, -1)
 }
 
 // ---- Style parsing ----
 
-func parseStyleBlock(css string, styles map[string]CueStyle) {
-	matches := reCueVoice.FindAllStringSubmatch(css, -1)
-	for _, m := range matches {
-		voice := m[1]
-		style := parseCSSProperties(m[2])
-		styles[voice] = style
+func parseStyleBlock(css string, styles, classes map[string]CueStyle) {
+	for _, m := range reCueVoice.FindAllStringSubmatch(css, -1) {
+		styles[m[1]] = parseCSSProperties(m[2])
+	}
+	for _, m := range reCueClass.FindAllStringSubmatch(css, -1) {
+		classes[m[1]] = parseCSSProperties(m[2])
 	}
 }
 


### PR DESCRIPTION
- Apply CueStyle.Italic to the Style line and inline voice spans
- Replace \r reset with explicit inverse overrides so nested `<b>/<i>`
  and voice/class spans no longer clobber outer formatting
- Escape { and } in cue text so literal braces don't open ASS override
  blocks; newline -> \N preserved
- Support 3-char (#RGB) and 8-char (#RRGGBBAA) hex, with the ASS alpha
  byte computed as 255-AA
- Expand the named-colour map (orange, purple, pink, ...)
- Honour line:X% for any explicit value, not just X != 90; gate on the
  -1 sentinel instead
- Apply align (-> \an) and position (-> \pos x) cue settings; top-row
  alignment when line is set, bottom-row otherwise
- Parse ::cue(.className) and apply styles on <c.class> spans
- Track current colour through the render so nested colour spans restore
  the outer colour rather than the line-style colour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added support for CSS class-based styling in VTT files (`.className` syntax) alongside existing voice-based styling

**Bug Fixes**
- Improved consistency of italic and bold formatting in subtitle rendering
- Extended colour conversion to support additional CSS colour formats, including #RGB, #RRGGBB, and #RRGGBBAA variants
- Refined inline formatting and text escape sequence handling for better output quality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->